### PR TITLE
`/Resources` folder use *.json files to save model. The *.xml files are only used for reading.

### DIFF
--- a/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jaGFuZ2VhbmFseXNpcy9jaGFuZ2Vz/2021-04-01.json
+++ b/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jaGFuZ2VhbmFseXNpcy9jaGFuZ2Vz/2021-04-01.json
@@ -1,0 +1,636 @@
+{
+    "plane": "mgmt-plane",
+    "resources": [
+        {
+            "id": "/subscriptions/{}/providers/microsoft.changeanalysis/changes",
+            "version": "2021-04-01",
+            "swagger": "mgmt-plane/changeanalysis/ResourceProviders/Microsoft.ChangeAnalysis/Paths/L3N1YnNjcmlwdGlvbnMve3N1YnNjcmlwdGlvbklkfS9wcm92aWRlcnMvTWljcm9zb2Z0LkNoYW5nZUFuYWx5c2lzL2NoYW5nZXM=/V/MjAyMS0wNC0wMQ=="
+        },
+        {
+            "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.changeanalysis/changes",
+            "version": "2021-04-01",
+            "swagger": "mgmt-plane/changeanalysis/ResourceProviders/Microsoft.ChangeAnalysis/Paths/L3N1YnNjcmlwdGlvbnMve3N1YnNjcmlwdGlvbklkfS9yZXNvdXJjZUdyb3Vwcy97cmVzb3VyY2VHcm91cE5hbWV9L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ2hhbmdlQW5hbHlzaXMvY2hhbmdlcw==/V/MjAyMS0wNC0wMQ=="
+        }
+    ],
+    "commandGroups": [
+        {
+            "name": "change-analysis",
+            "commands": [
+                {
+                    "name": "list",
+                    "version": "2021-04-01",
+                    "resources": [
+                        {
+                            "id": "/subscriptions/{}/providers/microsoft.changeanalysis/changes",
+                            "version": "2021-04-01",
+                            "swagger": "mgmt-plane/changeanalysis/ResourceProviders/Microsoft.ChangeAnalysis/Paths/L3N1YnNjcmlwdGlvbnMve3N1YnNjcmlwdGlvbklkfS9wcm92aWRlcnMvTWljcm9zb2Z0LkNoYW5nZUFuYWx5c2lzL2NoYW5nZXM=/V/MjAyMS0wNC0wMQ=="
+                        },
+                        {
+                            "id": "/subscriptions/{}/resourcegroups/{}/providers/microsoft.changeanalysis/changes",
+                            "version": "2021-04-01",
+                            "swagger": "mgmt-plane/changeanalysis/ResourceProviders/Microsoft.ChangeAnalysis/Paths/L3N1YnNjcmlwdGlvbnMve3N1YnNjcmlwdGlvbklkfS9yZXNvdXJjZUdyb3Vwcy97cmVzb3VyY2VHcm91cE5hbWV9L3Byb3ZpZGVycy9NaWNyb3NvZnQuQ2hhbmdlQW5hbHlzaXMvY2hhbmdlcw==/V/MjAyMS0wNC0wMQ=="
+                        }
+                    ],
+                    "argGroups": [
+                        {
+                            "name": "",
+                            "args": [
+                                {
+                                    "type": "ResourceGroupName",
+                                    "var": "$Path.resourceGroupName",
+                                    "options": [
+                                        "resource-group",
+                                        "g"
+                                    ]
+                                },
+                                {
+                                    "type": "SubscriptionId",
+                                    "var": "$Path.subscriptionId",
+                                    "options": [
+                                        "subscription"
+                                    ],
+                                    "required": true
+                                },
+                                {
+                                    "type": "dateTime",
+                                    "var": "$Query.endTime",
+                                    "options": [
+                                        "end-time"
+                                    ],
+                                    "required": true,
+                                    "help": {
+                                        "short": "Specifies the end time of the changes request."
+                                    }
+                                },
+                                {
+                                    "type": "string",
+                                    "var": "$Query.skipToken",
+                                    "options": [
+                                        "skip-token"
+                                    ],
+                                    "help": {
+                                        "short": "A skip token is used to continue retrieving items after an operation returns a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls."
+                                    }
+                                },
+                                {
+                                    "type": "dateTime",
+                                    "var": "$Query.startTime",
+                                    "options": [
+                                        "start-time"
+                                    ],
+                                    "required": true,
+                                    "help": {
+                                        "short": "Specifies the start time of the changes request."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "conditions": [
+                        {
+                            "var": "$Condition_Changes_ListChangesByResourceGroup",
+                            "operator": {
+                                "type": "and",
+                                "operators": [
+                                    {
+                                        "type": "hasValue",
+                                        "arg": "$Path.resourceGroupName"
+                                    },
+                                    {
+                                        "type": "hasValue",
+                                        "arg": "$Path.subscriptionId"
+                                    },
+                                    {
+                                        "type": "hasValue",
+                                        "arg": "$Query.endTime"
+                                    },
+                                    {
+                                        "type": "hasValue",
+                                        "arg": "$Query.startTime"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "var": "$Condition_Changes_ListChangesBySubscription",
+                            "operator": {
+                                "type": "and",
+                                "operators": [
+                                    {
+                                        "type": "hasValue",
+                                        "arg": "$Path.subscriptionId"
+                                    },
+                                    {
+                                        "type": "hasValue",
+                                        "arg": "$Query.endTime"
+                                    },
+                                    {
+                                        "type": "hasValue",
+                                        "arg": "$Query.startTime"
+                                    },
+                                    {
+                                        "type": "not",
+                                        "operator": {
+                                            "type": "hasValue",
+                                            "arg": "$Path.resourceGroupName"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "operations": [
+                        {
+                            "when": [
+                                "$Condition_Changes_ListChangesByResourceGroup"
+                            ],
+                            "operationId": "Changes_ListChangesByResourceGroup",
+                            "http": {
+                                "path": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ChangeAnalysis/changes",
+                                "request": {
+                                    "method": "get",
+                                    "path": {
+                                        "params": [
+                                            {
+                                                "type": "string",
+                                                "name": "resourceGroupName",
+                                                "arg": "$Path.resourceGroupName",
+                                                "required": true,
+                                                "format": {
+                                                    "maxLength": 90,
+                                                    "minLength": 1
+                                                }
+                                            },
+                                            {
+                                                "type": "string",
+                                                "name": "subscriptionId",
+                                                "arg": "$Path.subscriptionId",
+                                                "required": true,
+                                                "format": {
+                                                    "minLength": 1
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "query": {
+                                        "params": [
+                                            {
+                                                "type": "dateTime",
+                                                "name": "$endTime",
+                                                "arg": "$Query.endTime",
+                                                "required": true
+                                            },
+                                            {
+                                                "type": "string",
+                                                "name": "$skipToken",
+                                                "arg": "$Query.skipToken"
+                                            },
+                                            {
+                                                "type": "dateTime",
+                                                "name": "$startTime",
+                                                "arg": "$Query.startTime",
+                                                "required": true
+                                            }
+                                        ],
+                                        "consts": [
+                                            {
+                                                "readOnly": true,
+                                                "const": true,
+                                                "default": {
+                                                    "value": "2021-04-01"
+                                                },
+                                                "type": "string",
+                                                "name": "api-version",
+                                                "required": true,
+                                                "format": {
+                                                    "minLength": 1
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "responses": [
+                                    {
+                                        "statusCode": [
+                                            200
+                                        ],
+                                        "body": {
+                                            "json": {
+                                                "var": "$Instance",
+                                                "schema": {
+                                                    "type": "object",
+                                                    "props": [
+                                                        {
+                                                            "type": "string",
+                                                            "name": "nextLink"
+                                                        },
+                                                        {
+                                                            "type": "array<object>",
+                                                            "name": "value",
+                                                            "item": {
+                                                                "type": "object",
+                                                                "props": [
+                                                                    {
+                                                                        "readOnly": true,
+                                                                        "type": "string",
+                                                                        "name": "id"
+                                                                    },
+                                                                    {
+                                                                        "readOnly": true,
+                                                                        "type": "string",
+                                                                        "name": "name"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "name": "properties",
+                                                                        "props": [
+                                                                            {
+                                                                                "type": "string",
+                                                                                "name": "changeType",
+                                                                                "enum": {
+                                                                                    "items": [
+                                                                                        {
+                                                                                            "value": "Add"
+                                                                                        },
+                                                                                        {
+                                                                                            "value": "Remove"
+                                                                                        },
+                                                                                        {
+                                                                                            "value": "Update"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "array<string>",
+                                                                                "name": "initiatedByList",
+                                                                                "item": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "array<object>",
+                                                                                "name": "propertyChanges",
+                                                                                "item": {
+                                                                                    "type": "object",
+                                                                                    "props": [
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "changeCategory",
+                                                                                            "enum": {
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "value": "System"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "User"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "changeType",
+                                                                                            "enum": {
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "value": "Add"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Remove"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Update"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "description"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "displayName"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "boolean",
+                                                                                            "name": "isDataMasked"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "jsonPath"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "level",
+                                                                                            "enum": {
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "value": "Important"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Noisy"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Normal"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "newValue"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "oldValue"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "string",
+                                                                                "name": "resourceId"
+                                                                            },
+                                                                            {
+                                                                                "type": "dateTime",
+                                                                                "name": "timeStamp"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "readOnly": true,
+                                                                        "type": "string",
+                                                                        "name": "type"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "isError": true,
+                                        "body": {
+                                            "json": {
+                                                "schema": {
+                                                    "type": "@MgmtErrorFormat"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "when": [
+                                "$Condition_Changes_ListChangesBySubscription"
+                            ],
+                            "operationId": "Changes_ListChangesBySubscription",
+                            "http": {
+                                "path": "/subscriptions/{subscriptionId}/providers/Microsoft.ChangeAnalysis/changes",
+                                "request": {
+                                    "method": "get",
+                                    "path": {
+                                        "params": [
+                                            {
+                                                "type": "string",
+                                                "name": "subscriptionId",
+                                                "arg": "$Path.subscriptionId",
+                                                "required": true,
+                                                "format": {
+                                                    "minLength": 1
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "query": {
+                                        "params": [
+                                            {
+                                                "type": "dateTime",
+                                                "name": "$endTime",
+                                                "arg": "$Query.endTime",
+                                                "required": true
+                                            },
+                                            {
+                                                "type": "string",
+                                                "name": "$skipToken",
+                                                "arg": "$Query.skipToken"
+                                            },
+                                            {
+                                                "type": "dateTime",
+                                                "name": "$startTime",
+                                                "arg": "$Query.startTime",
+                                                "required": true
+                                            }
+                                        ],
+                                        "consts": [
+                                            {
+                                                "readOnly": true,
+                                                "const": true,
+                                                "default": {
+                                                    "value": "2021-04-01"
+                                                },
+                                                "type": "string",
+                                                "name": "api-version",
+                                                "required": true,
+                                                "format": {
+                                                    "minLength": 1
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "responses": [
+                                    {
+                                        "statusCode": [
+                                            200
+                                        ],
+                                        "body": {
+                                            "json": {
+                                                "var": "$Instance",
+                                                "schema": {
+                                                    "type": "object",
+                                                    "props": [
+                                                        {
+                                                            "type": "string",
+                                                            "name": "nextLink"
+                                                        },
+                                                        {
+                                                            "type": "array<object>",
+                                                            "name": "value",
+                                                            "item": {
+                                                                "type": "object",
+                                                                "props": [
+                                                                    {
+                                                                        "readOnly": true,
+                                                                        "type": "string",
+                                                                        "name": "id"
+                                                                    },
+                                                                    {
+                                                                        "readOnly": true,
+                                                                        "type": "string",
+                                                                        "name": "name"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "name": "properties",
+                                                                        "props": [
+                                                                            {
+                                                                                "type": "string",
+                                                                                "name": "changeType",
+                                                                                "enum": {
+                                                                                    "items": [
+                                                                                        {
+                                                                                            "value": "Add"
+                                                                                        },
+                                                                                        {
+                                                                                            "value": "Remove"
+                                                                                        },
+                                                                                        {
+                                                                                            "value": "Update"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "array<string>",
+                                                                                "name": "initiatedByList",
+                                                                                "item": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "array<object>",
+                                                                                "name": "propertyChanges",
+                                                                                "item": {
+                                                                                    "type": "object",
+                                                                                    "props": [
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "changeCategory",
+                                                                                            "enum": {
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "value": "System"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "User"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "changeType",
+                                                                                            "enum": {
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "value": "Add"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Remove"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Update"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "description"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "displayName"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "boolean",
+                                                                                            "name": "isDataMasked"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "jsonPath"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "level",
+                                                                                            "enum": {
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "value": "Important"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Noisy"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Normal"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "newValue"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "oldValue"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "string",
+                                                                                "name": "resourceId"
+                                                                            },
+                                                                            {
+                                                                                "type": "dateTime",
+                                                                                "name": "timeStamp"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "readOnly": true,
+                                                                        "type": "string",
+                                                                        "name": "type"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "isError": true,
+                                        "body": {
+                                            "json": {
+                                                "schema": {
+                                                    "type": "@MgmtErrorFormat"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "array",
+                            "ref": "$Instance.value",
+                            "clientFlatten": true,
+                            "nextLink": "$Instance.nextLink"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jaGFuZ2VhbmFseXNpcy9jaGFuZ2Vz/2021-04-01.xml
+++ b/Resources/mgmt-plane/L3N1YnNjcmlwdGlvbnMve30vcHJvdmlkZXJzL21pY3Jvc29mdC5jaGFuZ2VhbmFseXNpcy9jaGFuZ2Vz/2021-04-01.xml
@@ -53,7 +53,7 @@
               <param type="string" name="$skipToken" arg="$Query.skipToken"/>
               <param type="dateTime" name="$startTime" arg="$Query.startTime" required="True"/>
               <const readOnly="True" const="True" type="string" name="api-version" required="True">
-                <default value="2021-04-01"/>
+                <default value="&quot;2021-04-01&quot;"/>
                 <format minLength="1"/>
               </const>
             </query>
@@ -70,9 +70,9 @@
                       <prop type="object" name="properties">
                         <prop type="string" name="changeType">
                           <enum>
-                            <item value="Add"/>
-                            <item value="Remove"/>
-                            <item value="Update"/>
+                            <item value="&quot;Add&quot;"/>
+                            <item value="&quot;Remove&quot;"/>
+                            <item value="&quot;Update&quot;"/>
                           </enum>
                         </prop>
                         <prop type="array<string>" name="initiatedByList">
@@ -82,15 +82,15 @@
                           <item type="object">
                             <prop type="string" name="changeCategory">
                               <enum>
-                                <item value="System"/>
-                                <item value="User"/>
+                                <item value="&quot;System&quot;"/>
+                                <item value="&quot;User&quot;"/>
                               </enum>
                             </prop>
                             <prop type="string" name="changeType">
                               <enum>
-                                <item value="Add"/>
-                                <item value="Remove"/>
-                                <item value="Update"/>
+                                <item value="&quot;Add&quot;"/>
+                                <item value="&quot;Remove&quot;"/>
+                                <item value="&quot;Update&quot;"/>
                               </enum>
                             </prop>
                             <prop type="string" name="description"/>
@@ -99,9 +99,9 @@
                             <prop type="string" name="jsonPath"/>
                             <prop type="string" name="level">
                               <enum>
-                                <item value="Important"/>
-                                <item value="Noisy"/>
-                                <item value="Normal"/>
+                                <item value="&quot;Important&quot;"/>
+                                <item value="&quot;Noisy&quot;"/>
+                                <item value="&quot;Normal&quot;"/>
                               </enum>
                             </prop>
                             <prop type="string" name="newValue"/>
@@ -140,7 +140,7 @@
               <param type="string" name="$skipToken" arg="$Query.skipToken"/>
               <param type="dateTime" name="$startTime" arg="$Query.startTime" required="True"/>
               <const readOnly="True" const="True" type="string" name="api-version" required="True">
-                <default value="2021-04-01"/>
+                <default value="&quot;2021-04-01&quot;"/>
                 <format minLength="1"/>
               </const>
             </query>
@@ -157,9 +157,9 @@
                       <prop type="object" name="properties">
                         <prop type="string" name="changeType">
                           <enum>
-                            <item value="Add"/>
-                            <item value="Remove"/>
-                            <item value="Update"/>
+                            <item value="&quot;Add&quot;"/>
+                            <item value="&quot;Remove&quot;"/>
+                            <item value="&quot;Update&quot;"/>
                           </enum>
                         </prop>
                         <prop type="array<string>" name="initiatedByList">
@@ -169,15 +169,15 @@
                           <item type="object">
                             <prop type="string" name="changeCategory">
                               <enum>
-                                <item value="System"/>
-                                <item value="User"/>
+                                <item value="&quot;System&quot;"/>
+                                <item value="&quot;User&quot;"/>
                               </enum>
                             </prop>
                             <prop type="string" name="changeType">
                               <enum>
-                                <item value="Add"/>
-                                <item value="Remove"/>
-                                <item value="Update"/>
+                                <item value="&quot;Add&quot;"/>
+                                <item value="&quot;Remove&quot;"/>
+                                <item value="&quot;Update&quot;"/>
                               </enum>
                             </prop>
                             <prop type="string" name="description"/>
@@ -186,9 +186,9 @@
                             <prop type="string" name="jsonPath"/>
                             <prop type="string" name="level">
                               <enum>
-                                <item value="Important"/>
-                                <item value="Noisy"/>
-                                <item value="Normal"/>
+                                <item value="&quot;Important&quot;"/>
+                                <item value="&quot;Noisy&quot;"/>
+                                <item value="&quot;Normal&quot;"/>
                               </enum>
                             </prop>
                             <prop type="string" name="newValue"/>

--- a/Resources/mgmt-plane/L3tyZXNvdXJjZWlkfS9wcm92aWRlcnMvbWljcm9zb2Z0LmNoYW5nZWFuYWx5c2lzL3Jlc291cmNlY2hhbmdlcw==/2021-04-01.json
+++ b/Resources/mgmt-plane/L3tyZXNvdXJjZWlkfS9wcm92aWRlcnMvbWljcm9zb2Z0LmNoYW5nZWFuYWx5c2lzL3Jlc291cmNlY2hhbmdlcw==/2021-04-01.json
@@ -1,0 +1,318 @@
+{
+    "plane": "mgmt-plane",
+    "resources": [
+        {
+            "id": "/{resourceid}/providers/microsoft.changeanalysis/resourcechanges",
+            "version": "2021-04-01",
+            "swagger": "mgmt-plane/changeanalysis/ResourceProviders/Microsoft.ChangeAnalysis/Paths/L3tyZXNvdXJjZUlkfS9wcm92aWRlcnMvTWljcm9zb2Z0LkNoYW5nZUFuYWx5c2lzL3Jlc291cmNlQ2hhbmdlcw==/V/MjAyMS0wNC0wMQ=="
+        }
+    ],
+    "commandGroups": [
+        {
+            "name": "change-analysis",
+            "commands": [
+                {
+                    "name": "list-by-resource",
+                    "version": "2021-04-01",
+                    "resources": [
+                        {
+                            "id": "/{resourceid}/providers/microsoft.changeanalysis/resourcechanges",
+                            "version": "2021-04-01",
+                            "swagger": "mgmt-plane/changeanalysis/ResourceProviders/Microsoft.ChangeAnalysis/Paths/L3tyZXNvdXJjZUlkfS9wcm92aWRlcnMvTWljcm9zb2Z0LkNoYW5nZUFuYWx5c2lzL3Jlc291cmNlQ2hhbmdlcw==/V/MjAyMS0wNC0wMQ=="
+                        }
+                    ],
+                    "argGroups": [
+                        {
+                            "name": "",
+                            "args": [
+                                {
+                                    "type": "string",
+                                    "var": "$Path.resourceId",
+                                    "options": [
+                                        "resource",
+                                        "r"
+                                    ],
+                                    "required": true,
+                                    "help": {
+                                        "short": "The identifier of the resource."
+                                    }
+                                },
+                                {
+                                    "type": "dateTime",
+                                    "var": "$Query.endTime",
+                                    "options": [
+                                        "end-time"
+                                    ],
+                                    "required": true,
+                                    "help": {
+                                        "short": "Specifies the end time of the changes request."
+                                    }
+                                },
+                                {
+                                    "type": "string",
+                                    "var": "$Query.skipToken",
+                                    "options": [
+                                        "skip-token"
+                                    ],
+                                    "help": {
+                                        "short": "A skip token is used to continue retrieving items after an operation returns a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls."
+                                    }
+                                },
+                                {
+                                    "type": "dateTime",
+                                    "var": "$Query.startTime",
+                                    "options": [
+                                        "start-time"
+                                    ],
+                                    "required": true,
+                                    "help": {
+                                        "short": "Specifies the start time of the changes request."
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "operations": [
+                        {
+                            "operationId": "ResourceChanges_List",
+                            "http": {
+                                "path": "/{resourceId}/providers/Microsoft.ChangeAnalysis/resourceChanges",
+                                "request": {
+                                    "method": "post",
+                                    "path": {
+                                        "params": [
+                                            {
+                                                "type": "string",
+                                                "name": "resourceId",
+                                                "arg": "$Path.resourceId",
+                                                "required": true
+                                            }
+                                        ]
+                                    },
+                                    "query": {
+                                        "params": [
+                                            {
+                                                "type": "dateTime",
+                                                "name": "$endTime",
+                                                "arg": "$Query.endTime",
+                                                "required": true
+                                            },
+                                            {
+                                                "type": "string",
+                                                "name": "$skipToken",
+                                                "arg": "$Query.skipToken"
+                                            },
+                                            {
+                                                "type": "dateTime",
+                                                "name": "$startTime",
+                                                "arg": "$Query.startTime",
+                                                "required": true
+                                            }
+                                        ],
+                                        "consts": [
+                                            {
+                                                "readOnly": true,
+                                                "const": true,
+                                                "default": {
+                                                    "value": "2021-04-01"
+                                                },
+                                                "type": "string",
+                                                "name": "api-version",
+                                                "required": true,
+                                                "format": {
+                                                    "minLength": 1
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "responses": [
+                                    {
+                                        "statusCode": [
+                                            200
+                                        ],
+                                        "body": {
+                                            "json": {
+                                                "var": "$Instance",
+                                                "schema": {
+                                                    "type": "object",
+                                                    "props": [
+                                                        {
+                                                            "type": "string",
+                                                            "name": "nextLink"
+                                                        },
+                                                        {
+                                                            "type": "array<object>",
+                                                            "name": "value",
+                                                            "item": {
+                                                                "type": "object",
+                                                                "props": [
+                                                                    {
+                                                                        "readOnly": true,
+                                                                        "type": "string",
+                                                                        "name": "id"
+                                                                    },
+                                                                    {
+                                                                        "readOnly": true,
+                                                                        "type": "string",
+                                                                        "name": "name"
+                                                                    },
+                                                                    {
+                                                                        "type": "object",
+                                                                        "name": "properties",
+                                                                        "props": [
+                                                                            {
+                                                                                "type": "string",
+                                                                                "name": "changeType",
+                                                                                "enum": {
+                                                                                    "items": [
+                                                                                        {
+                                                                                            "value": "Add"
+                                                                                        },
+                                                                                        {
+                                                                                            "value": "Remove"
+                                                                                        },
+                                                                                        {
+                                                                                            "value": "Update"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "array<string>",
+                                                                                "name": "initiatedByList",
+                                                                                "item": {
+                                                                                    "type": "string"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "array<object>",
+                                                                                "name": "propertyChanges",
+                                                                                "item": {
+                                                                                    "type": "object",
+                                                                                    "props": [
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "changeCategory",
+                                                                                            "enum": {
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "value": "System"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "User"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "changeType",
+                                                                                            "enum": {
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "value": "Add"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Remove"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Update"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "description"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "displayName"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "boolean",
+                                                                                            "name": "isDataMasked"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "jsonPath"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "level",
+                                                                                            "enum": {
+                                                                                                "items": [
+                                                                                                    {
+                                                                                                        "value": "Important"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Noisy"
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "value": "Normal"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "newValue"
+                                                                                        },
+                                                                                        {
+                                                                                            "type": "string",
+                                                                                            "name": "oldValue"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "string",
+                                                                                "name": "resourceId"
+                                                                            },
+                                                                            {
+                                                                                "type": "dateTime",
+                                                                                "name": "timeStamp"
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "readOnly": true,
+                                                                        "type": "string",
+                                                                        "name": "type"
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "isError": true,
+                                        "body": {
+                                            "json": {
+                                                "schema": {
+                                                    "type": "@MgmtErrorFormat"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "type": "array",
+                            "ref": "$Instance.value",
+                            "clientFlatten": true,
+                            "nextLink": "$Instance.nextLink"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Resources/mgmt-plane/L3tyZXNvdXJjZWlkfS9wcm92aWRlcnMvbWljcm9zb2Z0LmNoYW5nZWFuYWx5c2lzL3Jlc291cmNlY2hhbmdlcw==/2021-04-01.xml
+++ b/Resources/mgmt-plane/L3tyZXNvdXJjZWlkfS9wcm92aWRlcnMvbWljcm9zb2Z0LmNoYW5nZWFuYWx5c2lzL3Jlc291cmNlY2hhbmdlcw==/2021-04-01.xml
@@ -29,7 +29,7 @@
               <param type="string" name="$skipToken" arg="$Query.skipToken"/>
               <param type="dateTime" name="$startTime" arg="$Query.startTime" required="True"/>
               <const readOnly="True" const="True" type="string" name="api-version" required="True">
-                <default value="2021-04-01"/>
+                <default value="&quot;2021-04-01&quot;"/>
                 <format minLength="1"/>
               </const>
             </query>
@@ -46,9 +46,9 @@
                       <prop type="object" name="properties">
                         <prop type="string" name="changeType">
                           <enum>
-                            <item value="Add"/>
-                            <item value="Remove"/>
-                            <item value="Update"/>
+                            <item value="&quot;Add&quot;"/>
+                            <item value="&quot;Remove&quot;"/>
+                            <item value="&quot;Update&quot;"/>
                           </enum>
                         </prop>
                         <prop type="array<string>" name="initiatedByList">
@@ -58,15 +58,15 @@
                           <item type="object">
                             <prop type="string" name="changeCategory">
                               <enum>
-                                <item value="System"/>
-                                <item value="User"/>
+                                <item value="&quot;System&quot;"/>
+                                <item value="&quot;User&quot;"/>
                               </enum>
                             </prop>
                             <prop type="string" name="changeType">
                               <enum>
-                                <item value="Add"/>
-                                <item value="Remove"/>
-                                <item value="Update"/>
+                                <item value="&quot;Add&quot;"/>
+                                <item value="&quot;Remove&quot;"/>
+                                <item value="&quot;Update&quot;"/>
                               </enum>
                             </prop>
                             <prop type="string" name="description"/>
@@ -75,9 +75,9 @@
                             <prop type="string" name="jsonPath"/>
                             <prop type="string" name="level">
                               <enum>
-                                <item value="Important"/>
-                                <item value="Noisy"/>
-                                <item value="Normal"/>
+                                <item value="&quot;Important&quot;"/>
+                                <item value="&quot;Noisy&quot;"/>
+                                <item value="&quot;Normal&quot;"/>
                               </enum>
                             </prop>
                             <prop type="string" name="newValue"/>


### PR DESCRIPTION
Currently, there are some issues in xml serializers, so we plan to replace it by *.json to save the model. Keep *.xml for reading only